### PR TITLE
feat: add permissions_boundary support for IAM role

### DIFF
--- a/modules/eventbridge-rule/iam.tf
+++ b/modules/eventbridge-rule/iam.tf
@@ -54,6 +54,8 @@ module "role" {
     var.default_execution_role.inline_policies
   )
 
+  permissions_boundary = var.default_execution_role.permissions_boundary
+
   force_detach_policies  = true
   resource_group_enabled = false
   module_tags_enabled    = false

--- a/modules/eventbridge-rule/variables.tf
+++ b/modules/eventbridge-rule/variables.tf
@@ -44,6 +44,7 @@ variable "default_execution_role" {
     (Optional) `description` - The description of the default execution role.
     (Optional) `policies` - A list of IAM policy ARNs to attach to the default execution role. Defaults to `[]`.
     (Optional) `inline_policies` - A Map of inline IAM policies to attach to the default execution role. (`name` => `policy`).
+    (Optional) `permissions_boundary` - The ARN of the IAM policy to use as permissions boundary for the default execution role.
   EOF
   type = object({
     enabled     = optional(bool, true)
@@ -51,8 +52,9 @@ variable "default_execution_role" {
     path        = optional(string, "/")
     description = optional(string, "Managed by Terraform.")
 
-    policies        = optional(list(string), [])
-    inline_policies = optional(map(string), {})
+    policies             = optional(list(string), [])
+    inline_policies      = optional(map(string), {})
+    permissions_boundary = optional(string)
   })
   default  = {}
   nullable = false


### PR DESCRIPTION
## Summary

This PR adds `permissions_boundary` parameter support to IAM roles in modules that use the `terraform-aws-account` `iam-role` module. This allows users to configure IAM permissions boundaries for better security control.

## Changes

### modules/eventbridge-rule
- **iam.tf**: Added `permissions_boundary` parameter to `module "role"`
- **variables.tf**: Added `permissions_boundary = optional(string)` to `default_execution_role` variable

## Reference

This change follows the pattern established in: https://github.com/tedilabs/terraform-aws-security/commit/a65368004de7769c5bc281d255293c1c734743ed